### PR TITLE
security: remove live account data from public repo, add LICENSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,19 @@ venv.bak/
 ehthumbs.db
 Thumbs.db
 
+# Run outputs — these contain live position, balance and account data.
+# Never commit them: a single export exposes entries, notional, leverage
+# and liquidation prices for every open position.
+risk_analysis.json
+*_analysis.json
+*_analysis.csv
+*_positions.json
+*_report.json
+positions.json
+portfolio.json
+output/
+reports/
+
 # Logs
 *.log
 logs/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pedro Domingues
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -137,26 +137,26 @@ The main system orchestrates the entire risk analysis workflow:
 Position 1: EXMPL/USDT:USDT
 ----------------------------------------
 Current Status:
-  Entry: $1.000000 | Current: $1.012000 | PnL: 0.56%
-  Size: 500.0 | Notional: $500.00 | Leverage: 15.0x
+  Entry: $1.000000 | Current: $1.012000 | PnL: 1.20%
+  Size: 500.0 | Notional: $500.00 | Leverage: 10.0x
 
 Volatility Analysis:
   Method: VOL_BLEND (GARCH 30% + HAR 40% + ATR 30%)
-  ATR(20): $0.014500 (1.46% of price)
+  ATR(20): $0.014500 (1.45% of price)
   HAR-RV σ(annual): 16.2%
   GARCH σ(annual): 93.3%
   Blended σ(4h): 2.1%
 
 🎯 Recommended Levels:
-  STOP LOSS: $0.985000 (-0.35% from entry)
-    💰 Optimal Risk: $3.08 (for optimal size: 1200.00)
-    💰 Current Risk: $0.53 (for current size: 500.00)
+  STOP LOSS: $0.985000 (-1.50% from entry)
+    💰 Optimal Risk: $18.00 (for optimal size: 1200.00)
+    💰 Current Risk: $7.50 (for current size: 500.00)
     ✅ Safe from liquidation
-  TAKE PROFIT: $1.030000 (0.69% from entry)
-    💰 Optimal Reward: $6.11
-    💰 Current Reward: $1.06
-    📊 Risk/Reward: 1.98:1
-    ℹ️  POSITION SIZE SMALL: Current is 0.2x optimal
+  TAKE PROFIT: $1.030000 (3.00% from entry)
+    💰 Optimal Reward: $36.00
+    💰 Current Reward: $15.00
+    📊 Risk/Reward: 2.00:1
+    ℹ️  POSITION SIZE SMALL: Current is 0.4x optimal
 
 Risk Assessment:
   Status: 🟢 NORMAL
@@ -276,8 +276,8 @@ Portfolio Risk/Reward: 1.76:1
 
 #### 1. Current Status
 ```
-Entry: $1.000000 | Current: $1.012000 | PnL: 0.56%
-Size: 500.0 | Notional: $500.00 | Leverage: 15.0x
+Entry: $1.000000 | Current: $1.012000 | PnL: 1.20%
+Size: 500.0 | Notional: $500.00 | Leverage: 10.0x
 ```
 - **Entry**: Position entry price
 - **Current**: Live market price
@@ -289,7 +289,7 @@ Size: 500.0 | Notional: $500.00 | Leverage: 15.0x
 #### 2. Volatility Analysis
 ```
 Method: VOL_BLEND (GARCH 30% + HAR 40% + ATR 30%)
-ATR(20): $0.014500 (1.46% of price)
+ATR(20): $0.014500 (1.45% of price)
 HAR-RV σ(annual): 16.2%
 GARCH σ(annual): 93.3%
 Blended σ(4h): 2.1%
@@ -302,15 +302,15 @@ Blended σ(4h): 2.1%
 
 #### 3. Risk Management Levels
 ```
-STOP LOSS: $0.985000 (-0.35% from entry)
-  💰 Optimal Risk: $3.08 (for optimal size: 1200.00)
-  💰 Current Risk: $0.53 (for current size: 500.00)
+STOP LOSS: $0.985000 (-1.50% from entry)
+  💰 Optimal Risk: $18.00 (for optimal size: 1200.00)
+  💰 Current Risk: $7.50 (for current size: 500.00)
   ✅ Safe from liquidation
 
-TAKE PROFIT: $1.030000 (0.69% from entry)
-  💰 Optimal Reward: $6.11
-  💰 Current Reward: $1.06
-  📊 Risk/Reward: 1.98:1
+TAKE PROFIT: $1.030000 (3.00% from entry)
+  💰 Optimal Reward: $36.00
+  💰 Current Reward: $15.00
+  📊 Risk/Reward: 2.00:1
 ```
 - **SL/TP Levels**: Calculated based on volatility and multipliers
 - **Optimal Risk/Reward**: Based on optimal position size for target risk


### PR DESCRIPTION
Addresses prompt 2. **Update: the history purge has now been done** — see the last section.

## What was exposed

`risk_analysis.json` was a committed run output containing **9 real open leveraged positions**, timestamped `2025-08-10T23:45:46Z`:

| Field | Value |
|---|---|
| Positions | 9 (AERO, ARB, OP, VINE, ENA, MILK, THETA, ADA, ROSE) |
| Total notional | $14,770.13 |
| Peak leverage | **20x** (ADA, ENA) — the audit note said 17x |
| Also present | entry prices, live prices, unrealised PnL, liquidation prices |

## Finding the audit missed

The prompt named only `risk_analysis.json`. **`README.md` also embedded a real position** — the "Output Example" and "Understanding the Outputs" blocks reproduced the live `ARB/USDT:USDT` entry `$0.460210`, size `331.0`, notional `$152.33`, 15x, matching the JSON exactly.

Both are now a synthetic `EXMPL/USDT:USDT` example with internally consistent numbers (entry $1.00, size 500, 10x, SL -1.50%, TP +3.00%, R/R 2.00:1). The `$2,450.33` portfolio block was already fictional and is untouched.

## Changes in this PR

- **Delete** `risk_analysis.json`
- **Scrub** the real position from the two README example blocks
- **`.gitignore`** — `risk_analysis.json`, `*_analysis.json`, `*_analysis.csv`, `*_positions.json`, `*_report.json`, `positions.json`, `portfolio.json`, `output/`, `reports/`. Verified a regenerated output is now ignored.
- **Add MIT `LICENSE`** — `README.md:514` has always claimed MIT with no file present.

`market_analysis/` is untouched, as instructed.

## ✅ History purge — completed

Two `git filter-repo` passes were run and force-pushed across **all 6 branches**. A mirror backup was taken first.

**Pass 1** removed the `risk_analysis.json` path. **Pass 2 was necessary and is the important one:** verifying pass 1 from a fresh clone showed **52 surviving blobs** still containing the real entry price. Removing the JSON path had done nothing about the README, which carried the same live position across **26 commits** and was still serving it on `clean-main`. Pass 2 redacted the identifying values (`ARB/USDT:USDT`, `0.460210`, `0.462700`, `0.458600`, `0.463400`, `0.006705`, `152.33`, `331.0`, `1916.08`) throughout history.

Verified from a **fresh clone of the live remote**:

| Check | Result |
|---|---|
| commits touching `risk_analysis.json` | **0** |
| blobs containing `0.460210` | **0** |
| blobs containing `ARB/USDT` | **0** |
| blobs containing `152.33` | **0** |

Every commit SHA changed. **Any existing clone of this repo must be deleted and re-cloned** — `git pull` will fail.

⚠️ **One residual risk you should close manually:** GitHub retains unreferenced objects for a period, so the old commits may still be reachable by direct SHA URL until garbage collection. To force it, contact GitHub Support and ask them to purge the cached views for this repository, citing removal of sensitive data.

## Still outstanding

- **Branch rename** `clean-main` → `main` — a repo setting; no tooling available here.
- **Scratch branch deletion** (`cursor/…-083c`, `cursor/…-d787`, `revert`) — this session's git proxy refuses delete refspecs and the GitHub MCP set has no delete-branch tool. They have been rewritten clean, so they no longer carry the data, but they still need deleting by hand. `fix-docs-dependency` was not on the delete list and was left alone.

## Unrelated pre-existing breakage (reported, not fixed)

`.github/workflows/run-risk-manager.yml` invokes `python risk-manager.py`, which does not exist after the package restructure (entry point is now `market_analysis/__main__.py`), and its `python-version:` line is corrupted. This workflow cannot succeed.